### PR TITLE
Add delete patten definition to CSV/TSV output

### DIFF
--- a/example-basic-m3bp/src/main/java/com/example/jobflow/CategorySummaryToCsv.java
+++ b/example-basic-m3bp/src/main/java/com/example/jobflow/CategorySummaryToCsv.java
@@ -40,4 +40,9 @@ public class CategorySummaryToCsv extends AbstractCategorySummaryCsvOutputDescri
     public List<String> getOrder() {
         return Arrays.asList("-selling_price_total");
     }
+
+    @Override
+    public List<String> getDeletePatterns() {
+        return Arrays.asList("*");
+    }
 }

--- a/example-basic-m3bp/src/main/java/com/example/jobflow/ErrorRecordToCsv.java
+++ b/example-basic-m3bp/src/main/java/com/example/jobflow/ErrorRecordToCsv.java
@@ -40,4 +40,9 @@ public class ErrorRecordToCsv extends AbstractErrorRecordCsvOutputDescription {
     public List<String> getOrder() {
         return Arrays.asList("+file_name");
     }
+
+    @Override
+    public List<String> getDeletePatterns() {
+        return Arrays.asList("*");
+    }
 }

--- a/example-basic-spark/src/main/java/com/example/jobflow/CategorySummaryToCsv.java
+++ b/example-basic-spark/src/main/java/com/example/jobflow/CategorySummaryToCsv.java
@@ -40,4 +40,9 @@ public class CategorySummaryToCsv extends AbstractCategorySummaryCsvOutputDescri
     public List<String> getOrder() {
         return Arrays.asList("-selling_price_total");
     }
+
+    @Override
+    public List<String> getDeletePatterns() {
+        return Arrays.asList("*");
+    }
 }

--- a/example-basic-spark/src/main/java/com/example/jobflow/ErrorRecordToCsv.java
+++ b/example-basic-spark/src/main/java/com/example/jobflow/ErrorRecordToCsv.java
@@ -40,4 +40,9 @@ public class ErrorRecordToCsv extends AbstractErrorRecordCsvOutputDescription {
     public List<String> getOrder() {
         return Arrays.asList("+file_name");
     }
+
+    @Override
+    public List<String> getDeletePatterns() {
+        return Arrays.asList("*");
+    }
 }

--- a/example-directio-csv/src/main/java/com/example/jobflow/CategorySummaryToCsv.java
+++ b/example-directio-csv/src/main/java/com/example/jobflow/CategorySummaryToCsv.java
@@ -40,4 +40,9 @@ public class CategorySummaryToCsv extends AbstractCategorySummaryCsvOutputDescri
     public List<String> getOrder() {
         return Arrays.asList("-selling_price_total");
     }
+
+    @Override
+    public List<String> getDeletePatterns() {
+        return Arrays.asList("*");
+    }
 }

--- a/example-directio-csv/src/main/java/com/example/jobflow/ErrorRecordToCsv.java
+++ b/example-directio-csv/src/main/java/com/example/jobflow/ErrorRecordToCsv.java
@@ -40,4 +40,9 @@ public class ErrorRecordToCsv extends AbstractErrorRecordCsvOutputDescription {
     public List<String> getOrder() {
         return Arrays.asList("+file_name");
     }
+
+    @Override
+    public List<String> getDeletePatterns() {
+        return Arrays.asList("*");
+    }
 }

--- a/example-directio-tsv/src/main/java/com/example/jobflow/CategorySummaryToTsv.java
+++ b/example-directio-tsv/src/main/java/com/example/jobflow/CategorySummaryToTsv.java
@@ -40,4 +40,9 @@ public class CategorySummaryToTsv extends AbstractCategorySummaryTsvOutputDescri
     public List<String> getOrder() {
         return Arrays.asList("-selling_price_total");
     }
+
+    @Override
+    public List<String> getDeletePatterns() {
+        return Arrays.asList("*");
+    }
 }

--- a/example-directio-tsv/src/main/java/com/example/jobflow/ErrorRecordToTsv.java
+++ b/example-directio-tsv/src/main/java/com/example/jobflow/ErrorRecordToTsv.java
@@ -40,4 +40,9 @@ public class ErrorRecordToTsv extends AbstractErrorRecordTsvOutputDescription {
     public List<String> getOrder() {
         return Arrays.asList("+file_name");
     }
+
+    @Override
+    public List<String> getDeletePatterns() {
+        return Arrays.asList("*");
+    }
 }

--- a/example-multiproject/app-proj/src/main/java/com/example/jobflow/CategorySummaryToCsv.java
+++ b/example-multiproject/app-proj/src/main/java/com/example/jobflow/CategorySummaryToCsv.java
@@ -40,4 +40,9 @@ public class CategorySummaryToCsv extends AbstractCategorySummaryCsvOutputDescri
     public List<String> getOrder() {
         return Arrays.asList("-selling_price_total");
     }
+
+    @Override
+    public List<String> getDeletePatterns() {
+        return Arrays.asList("*");
+    }
 }

--- a/example-multiproject/app-proj/src/main/java/com/example/jobflow/ErrorRecordToCsv.java
+++ b/example-multiproject/app-proj/src/main/java/com/example/jobflow/ErrorRecordToCsv.java
@@ -40,4 +40,9 @@ public class ErrorRecordToCsv extends AbstractErrorRecordCsvOutputDescription {
     public List<String> getOrder() {
         return Arrays.asList("+file_name");
     }
+
+    @Override
+    public List<String> getDeletePatterns() {
+        return Arrays.asList("*");
+    }
 }


### PR DESCRIPTION
## Summary

This PR adds delete pattern definitions to CSV/TSV export modules.

## Background, Problem or Goal of the patch

Without delete patterns, lingering old files would be confusing and/or annoying.

## Design of the fix, or a new feature

Each output class overrides `getDeletePattarns` method.

## Related Issue, Pull Request or Code

None.

## Wanted reviewer

@akirakw 
