### PR TITLE
Remove datetime to string conversion from parquet

### DIFF
--- a/example-directio-hive/src/main/dmdl/models.dmdl
+++ b/example-directio-hive/src/main/dmdl/models.dmdl
@@ -109,7 +109,6 @@ summarized category_summary = joined_sales_info => {
 error_record = {
 
     "売上日時"
-    @directio.hive.string
     sales_date_time : DATETIME;
 
     "店舗コード"


### PR DESCRIPTION
## Summary
This PR modifies example to remove datetime to string conversion from parquet output.

## Background, Problem or Goal of the patch
Parquet with timestamp has been supported from Hive version 0.14.0, so Direct I/O Hive example should show to use timestamp directly ( not to use string conversion ) at this time.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.

## Wanted reviewer
N/A.

