### PR TITLE
Bump 0.9.0-SNAPSHOT for example-thundergate

### DIFF
--- a/example-thundergate/build.gradle
+++ b/example-thundergate/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw', name: 'asakusa-gradle-plugins', version: '0.8.1'
+        classpath group: 'com.asakusafw.legacy', name: 'asakusa-legacy-gradle', version: '0.9.0-SNAPSHOT'
     }
 }
 


### PR DESCRIPTION
## Summary
This PR bumps up example-thundergate to 0.9.0-SNAPSHOT.

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
This PR also changes Gradle Plugin on the project.
Gradle Plugin for ThunderGate moves to `asakusa-legacy-gradle`
(see: asakusafw/asakusafw-legacy#16). 

**[ATTENTION]** Currently,  version 0.9.0 is only for maintenance, does not have a plan to  release (see: asakusafw/asakusafw-legacy#15). 

## Related Issue, Pull Request or Code
* asakusafw/asakusafw-legacy#15
* asakusafw/asakusafw-legacy#16

## Wanted reviewer
N/A.
