### PR TITLE
Add batchapp that imports CSV files to DB tables

### DIFF
--- a/example-windgate-jdbc/src/main/dmdl/models.dmdl
+++ b/example-windgate-jdbc/src/main/dmdl/models.dmdl
@@ -1,6 +1,10 @@
 -- 入力テーブル形式
 
 "売上明細"
+@windgate.csv(
+    force_header = TRUE,
+    datetime = "yyyy-MM-dd HH:mm:ss"
+)
 @windgate.jdbc.table(
     name = "SALES_DETAIL"
 )
@@ -32,6 +36,7 @@ sales_detail = {
 };
 
 "店舗マスタ"
+@windgate.csv(force_header = TRUE)
 @windgate.jdbc.table(
     name = "STORE_INFO"
 )
@@ -47,6 +52,10 @@ store_info = {
 };
 
 "商品マスタ"
+@windgate.csv(
+    force_header = TRUE,
+    date = "yyyy-MM-dd"
+)
 @windgate.jdbc.table(
     name = "ITEM_INFO"
 )

--- a/example-windgate-jdbc/src/main/java/com/asakusafw/example/csvimport/batch/CsvImportBatch.java
+++ b/example-windgate-jdbc/src/main/java/com/asakusafw/example/csvimport/batch/CsvImportBatch.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.example.csvimport.batch;
+
+import com.asakusafw.example.csvimport.jobflow.CsvImportJob;
+import com.asakusafw.vocabulary.batch.Batch;
+import com.asakusafw.vocabulary.batch.BatchDescription;
+
+/**
+ * CSVファイルをテーブルにインポートする。
+ */
+@Batch(name = "example.csvImport")
+public class CsvImportBatch extends BatchDescription {
+
+    @Override
+    protected void describe() {
+        run(CsvImportJob.class).soon();
+    }
+}

--- a/example-windgate-jdbc/src/main/java/com/asakusafw/example/csvimport/jobflow/CsvImportJob.java
+++ b/example-windgate-jdbc/src/main/java/com/asakusafw/example/csvimport/jobflow/CsvImportJob.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.example.csvimport.jobflow;
+
+import com.asakusafw.example.jdbc.modelgen.dmdl.model.ItemInfo;
+import com.asakusafw.example.jdbc.modelgen.dmdl.model.SalesDetail;
+import com.asakusafw.example.jdbc.modelgen.dmdl.model.StoreInfo;
+import com.asakusafw.vocabulary.flow.Export;
+import com.asakusafw.vocabulary.flow.FlowDescription;
+import com.asakusafw.vocabulary.flow.Import;
+import com.asakusafw.vocabulary.flow.In;
+import com.asakusafw.vocabulary.flow.JobFlow;
+import com.asakusafw.vocabulary.flow.Out;
+
+/**
+ * CSVファイルをテーブルにインポートする。
+ */
+@JobFlow(name = "csvImport")
+public class CsvImportJob extends FlowDescription {
+
+    final In<SalesDetail> salesDetailIn;
+
+    final In<StoreInfo> storeInfoIn;
+
+    final In<ItemInfo> itemInfoIn;
+
+    final Out<SalesDetail> salesDetailOut;
+
+    final Out<StoreInfo> storeInfoOut;
+
+    final Out<ItemInfo> itemInfoOut;
+
+    /**
+     * ジョブフローインスタンスを生成する。
+     * 
+     * @param salesDetailIn
+     *            売上明細
+     * @param storeInfoIn
+     *            店舗マスタ
+     * @param itemInfoIn
+     *            商品マスタ
+     * @param salesDetailOut
+     *            売上明細
+     * @param storeInfoOut
+     *            店舗マスタ
+     * @param itemInfoOut
+     *            商品マスタ
+     */
+    public CsvImportJob(
+            @Import(name = "salesDetailIn", description = SalesDetailFromCsv.class) In<SalesDetail> salesDetailIn,
+            @Import(name = "storeInfoIn", description = StoreInfoFromCsv.class) In<StoreInfo> storeInfoIn,
+            @Import(name = "itemInfoIn", description = ItemInfoFromCsv.class) In<ItemInfo> itemInfoIn,
+            @Export(name = "salesDetailOut", description = SalesDetailToJdbc.class) Out<SalesDetail> salesDetailOut,
+            @Export(name = "storeInfoOut", description = StoreInfoToJdbc.class) Out<StoreInfo> storeInfoOut,
+            @Export(name = "itemInfoOut", description = ItemInfoToJdbc.class) Out<ItemInfo> itemInfoOut) {
+        this.salesDetailIn = salesDetailIn;
+        this.storeInfoIn = storeInfoIn;
+        this.itemInfoIn = itemInfoIn;
+        this.salesDetailOut = salesDetailOut;
+        this.storeInfoOut = storeInfoOut;
+        this.itemInfoOut = itemInfoOut;
+    }
+
+    @Override
+    protected void describe() {
+        salesDetailOut.add(salesDetailIn);
+        storeInfoOut.add(storeInfoIn);
+        itemInfoOut.add(itemInfoIn);
+    }
+}

--- a/example-windgate-jdbc/src/main/java/com/asakusafw/example/csvimport/jobflow/ItemInfoFromCsv.java
+++ b/example-windgate-jdbc/src/main/java/com/asakusafw/example/csvimport/jobflow/ItemInfoFromCsv.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.example.csvimport.jobflow;
+
+import com.asakusafw.example.jdbc.modelgen.dmdl.csv.AbstractItemInfoCsvImporterDescription;;
+
+/**
+ * 商品マスタをWindGate/CSVからインポートする。
+ * インポート対象ファイルは {@code master/item_info.csv}。
+ */
+public class ItemInfoFromCsv extends AbstractItemInfoCsvImporterDescription {
+
+    @Override
+    public String getProfileName() {
+        return "asakusa";
+    }
+
+    @Override
+    public String getPath() {
+        return "master/item_info.csv";
+    }
+
+    @Override
+    public DataSize getDataSize() {
+        return DataSize.LARGE;
+    }
+}

--- a/example-windgate-jdbc/src/main/java/com/asakusafw/example/csvimport/jobflow/ItemInfoToJdbc.java
+++ b/example-windgate-jdbc/src/main/java/com/asakusafw/example/csvimport/jobflow/ItemInfoToJdbc.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.example.csvimport.jobflow;
+
+import com.asakusafw.example.jdbc.modelgen.dmdl.jdbc.AbstractItemInfoJdbcExporterDescription;
+
+/**
+ * 商品マスタをWindGate/JDBCでエクスポートする。
+ * エクスポート対象テーブルは {@code ITEM_INFO}。
+ */
+public class ItemInfoToJdbc extends AbstractItemInfoJdbcExporterDescription {
+
+    @Override
+    public String getProfileName() {
+        return "asakusa";
+    }
+
+}

--- a/example-windgate-jdbc/src/main/java/com/asakusafw/example/csvimport/jobflow/SalesDetailFromCsv.java
+++ b/example-windgate-jdbc/src/main/java/com/asakusafw/example/csvimport/jobflow/SalesDetailFromCsv.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.example.csvimport.jobflow;
+
+import com.asakusafw.example.jdbc.modelgen.dmdl.csv.AbstractSalesDetailCsvImporterDescription;;
+
+/**
+ * 売上明細をWindGate/CSVからインポートする。
+ * インポート対象ファイルは {@code sales/*.csv}。
+ */
+public class SalesDetailFromCsv extends AbstractSalesDetailCsvImporterDescription {
+
+    @Override
+    public String getProfileName() {
+        return "asakusa";
+    }
+
+    @Override
+    public String getPath() {
+        return "sales/*.csv";
+    }
+
+    @Override
+    public DataSize getDataSize() {
+        return DataSize.LARGE;
+    }
+}

--- a/example-windgate-jdbc/src/main/java/com/asakusafw/example/csvimport/jobflow/SalesDetailToJdbc.java
+++ b/example-windgate-jdbc/src/main/java/com/asakusafw/example/csvimport/jobflow/SalesDetailToJdbc.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.example.csvimport.jobflow;
+
+import com.asakusafw.example.jdbc.modelgen.dmdl.jdbc.AbstractSalesDetailJdbcExporterDescription;
+
+/**
+ * 売上明細をWindGate/JDBCでエクスポートする。
+ * エクスポート対象テーブルは {@code SALES_DETAIL}。
+ */
+public class SalesDetailToJdbc extends AbstractSalesDetailJdbcExporterDescription {
+
+    @Override
+    public String getProfileName() {
+        return "asakusa";
+    }
+
+}

--- a/example-windgate-jdbc/src/main/java/com/asakusafw/example/csvimport/jobflow/StoreInfoFromCsv.java
+++ b/example-windgate-jdbc/src/main/java/com/asakusafw/example/csvimport/jobflow/StoreInfoFromCsv.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.example.csvimport.jobflow;
+
+import com.asakusafw.example.jdbc.modelgen.dmdl.csv.AbstractStoreInfoCsvImporterDescription;;
+
+/**
+ * 店舗マスタをWindGate/CSVからインポートする。
+ * インポート対象ファイルは {@code master/store_info.csv}。
+ */
+public class StoreInfoFromCsv extends AbstractStoreInfoCsvImporterDescription {
+
+    @Override
+    public String getProfileName() {
+        return "asakusa";
+    }
+
+    @Override
+    public String getPath() {
+        return "master/store_info.csv";
+    }
+
+    @Override
+    public DataSize getDataSize() {
+        // 店舗マスタは小さい前提
+        return DataSize.TINY;
+    }
+}

--- a/example-windgate-jdbc/src/main/java/com/asakusafw/example/csvimport/jobflow/StoreInfoToJdbc.java
+++ b/example-windgate-jdbc/src/main/java/com/asakusafw/example/csvimport/jobflow/StoreInfoToJdbc.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.example.csvimport.jobflow;
+
+import com.asakusafw.example.jdbc.modelgen.dmdl.jdbc.AbstractStoreInfoJdbcExporterDescription;
+
+/**
+ * 店舗マスタをWindGate/JDBCでエクスポートする。
+ * エクスポート対象テーブルは {@code STORE_INFO}。
+ */
+public class StoreInfoToJdbc extends AbstractStoreInfoJdbcExporterDescription {
+
+    @Override
+    public String getProfileName() {
+        return "asakusa";
+    }
+
+}


### PR DESCRIPTION
## Summary
This PR add example batchapp that imports CSV files to DB tables to `example-windgate-jdbc` project.

## Background, Problem or Goal of the patch
This batch is useful for preparing input data for `example.summarizeSales` on DB tables. It also shows dataflow that only has direct connection from input to output.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.

## Wanted reviewer
N/A.
