### PR TITLE
Remove MapReduce config from spark example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This includes following application projects:
 
 ### Asakusa on Spark
 
-* [`example-basic-spark`](example-basic-spark) - A basic batch application using [Asakusa on Spark](https://github.com/asakusafw/asakusafw-spark) and Asakusa on MapReduce
+* [`example-basic-spark`](example-basic-spark) - A basic batch application using [Asakusa on Spark](https://github.com/asakusafw/asakusafw-spark)
 
 ### Asakusa on M<sup>3</sup>BP
 

--- a/example-basic-spark/README.md
+++ b/example-basic-spark/README.md
@@ -1,6 +1,6 @@
 # Asakusa on Spark - Example Batch Application
 
-This project contains an example batch application working with [Asakusa on Spark](https://github.com/asakusafw/asakusafw-spark) and Asakusa on MapReduce.
+This project contains an example batch application working with [Asakusa on Spark](https://github.com/asakusafw/asakusafw-spark).
 
 ## How to build
 

--- a/example-basic-spark/build.gradle
+++ b/example-basic-spark/build.gradle
@@ -12,7 +12,6 @@ buildscript {
 
 apply plugin: 'asakusafw-sdk'
 apply plugin: 'asakusafw-organizer'
-apply plugin: 'asakusafw-mapreduce'
 apply plugin: 'asakusafw-spark'
 apply plugin: 'eclipse'
 


### PR DESCRIPTION
## Summary
This PR removes MapReduce configuration from `example-basic-spark` project.

## Background, Problem or Goal of the patch
This change is part to reorganize example repository and project structure.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.

## Wanted reviewer
N/A.
