### PR TITLE
Modify build.gradle for using `asakusafw.sdk` convention

### DIFF
--- a/example-basic-m3bp/build.gradle
+++ b/example-basic-m3bp/build.gradle
@@ -27,10 +27,3 @@ asakusafwOrganizer {
         }
     }
 }
-
-dependencies {
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-core', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-directio', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-windgate', version: asakusafw.asakusafwVersion
-    testRuntime group: 'com.asakusafw.sdk', name: 'asakusa-sdk-test-emulation', version: asakusafw.asakusafwVersion
-}

--- a/example-basic-spark/build.gradle
+++ b/example-basic-spark/build.gradle
@@ -23,10 +23,3 @@ asakusafwOrganizer {
         }
     }
 }
-
-dependencies {
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-core', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-directio', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-windgate', version: asakusafw.asakusafwVersion
-    testRuntime group: 'com.asakusafw.sdk', name: 'asakusa-sdk-test-emulation', version: asakusafw.asakusafwVersion
-}

--- a/example-directio-csv/build.gradle
+++ b/example-directio-csv/build.gradle
@@ -23,10 +23,3 @@ asakusafwOrganizer {
         }
     }
 }
-
-dependencies {
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-core', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-directio', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-windgate', version: asakusafw.asakusafwVersion
-    testRuntime group: 'com.asakusafw.sdk', name: 'asakusa-sdk-test-emulation', version: asakusafw.asakusafwVersion
-}

--- a/example-directio-hive/build.gradle
+++ b/example-directio-hive/build.gradle
@@ -16,15 +16,12 @@ apply plugin: 'asakusafw-mapreduce'
 apply plugin: 'asakusafw-spark'
 apply plugin: 'eclipse'
 
-asakusafwOrganizer {
-    hive.enabled true
+asakusafw {
+    sdk {
+        hive true
+    }
 }
 
-dependencies {
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-core', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-directio', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-windgate', version: asakusafw.asakusafwVersion
-    testRuntime group: 'com.asakusafw.sdk', name: 'asakusa-sdk-test-emulation', version: asakusafw.asakusafwVersion
-
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-hive', version: asakusafw.asakusafwVersion
+asakusafwOrganizer {
+    hive.enabled true
 }

--- a/example-directio-tsv/build.gradle
+++ b/example-directio-tsv/build.gradle
@@ -17,10 +17,5 @@ apply plugin: 'asakusafw-spark'
 apply plugin: 'eclipse'
 
 dependencies {
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-core', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-directio', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-windgate', version: asakusafw.asakusafwVersion
-    testRuntime group: 'com.asakusafw.sdk', name: 'asakusa-sdk-test-emulation', version: asakusafw.asakusafwVersion
-
-    compile group: 'com.asakusafw.sandbox', name: 'asakusa-directio-dmdl-ext', version: asakusafw.asakusafwVersion
+    compile group: 'com.asakusafw.sandbox', name: 'asakusa-directio-dmdl-ext', version: asakusafw.core.version
 }

--- a/example-multiproject/app-proj/build.gradle
+++ b/example-multiproject/app-proj/build.gradle
@@ -17,9 +17,5 @@ apply plugin: 'asakusafw-spark'
 apply plugin: 'eclipse'
 
 dependencies {
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-core', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-directio', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-windgate', version: asakusafw.asakusafwVersion
-
     compile project(':dmdl-proj')
 }

--- a/example-multiproject/dmdl-proj/build.gradle
+++ b/example-multiproject/dmdl-proj/build.gradle
@@ -15,9 +15,3 @@ apply plugin: 'asakusafw-organizer'
 apply plugin: 'asakusafw-mapreduce'
 apply plugin: 'asakusafw-spark'
 apply plugin: 'eclipse'
-
-dependencies {
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-core', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-directio', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-windgate', version: asakusafw.asakusafwVersion
-}

--- a/example-multiproject/test-proj/build.gradle
+++ b/example-multiproject/test-proj/build.gradle
@@ -17,10 +17,5 @@ apply plugin: 'asakusafw-spark'
 apply plugin: 'eclipse'
 
 dependencies {
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-core', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-directio', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-windgate', version: asakusafw.asakusafwVersion
-    testRuntime group: 'com.asakusafw.sdk', name: 'asakusa-sdk-test-emulation', version: asakusafw.asakusafwVersion
-
     compile project(':app-proj')
 }

--- a/example-summarize-sales/build.gradle
+++ b/example-summarize-sales/build.gradle
@@ -15,10 +15,3 @@ apply plugin: 'asakusafw-organizer'
 apply plugin: 'asakusafw-mapreduce'
 apply plugin: 'asakusafw-spark'
 apply plugin: 'eclipse'
-
-dependencies {
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-core', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-directio', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-windgate', version: asakusafw.asakusafwVersion
-    testRuntime group: 'com.asakusafw.sdk', name: 'asakusa-sdk-test-emulation', version: asakusafw.asakusafwVersion
-}

--- a/example-thundergate/build.gradle
+++ b/example-thundergate/build.gradle
@@ -30,9 +30,6 @@ asakusafwOrganizer {
 }
 
 dependencies {
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-core', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-thundergate', version: asakusafw.asakusafwVersion
-    testRuntime group: 'com.asakusafw.sdk', name: 'asakusa-sdk-test-emulation', version: asakusafw.asakusafwVersion
-
+    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-thundergate', version: asakusafw.core.version
     compile group: 'mysql', name: 'mysql-connector-java', version: '5.1.25'
 }

--- a/example-windgate-csv/build.gradle
+++ b/example-windgate-csv/build.gradle
@@ -15,11 +15,3 @@ apply plugin: 'asakusafw-organizer'
 apply plugin: 'asakusafw-mapreduce'
 apply plugin: 'asakusafw-spark'
 apply plugin: 'eclipse'
-
-dependencies {
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-core', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-directio', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-windgate', version: asakusafw.asakusafwVersion
-    testRuntime group: 'com.asakusafw.sdk', name: 'asakusa-sdk-test-emulation', version: asakusafw.asakusafwVersion
-}
-

--- a/example-windgate-jdbc/build.gradle
+++ b/example-windgate-jdbc/build.gradle
@@ -21,11 +21,6 @@ configurations {
 }
 
 dependencies {
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-core', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-directio', version: asakusafw.asakusafwVersion
-    compile group: 'com.asakusafw.sdk', name: 'asakusa-sdk-windgate', version: asakusafw.asakusafwVersion
-    testRuntime group: 'com.asakusafw.sdk', name: 'asakusa-sdk-test-emulation', version: asakusafw.asakusafwVersion
-
     jdbcDriver group: 'postgresql', name: 'postgresql', version: '9.1-901-1.jdbc4'
 }
 


### PR DESCRIPTION
## Summary
This PR modifies `build.gradle` in example projects for using `asakusafw.sdk` convention for configuring SDK ( asakusafw/asakusafw-sdk#109 ) 

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
This PR migrates dependency configuration for SDK from using sdk-artifact on dependencies block to use `asakusafw.sdk` convention on `build.gradle` .

## Related Issue, Pull Request or Code
asakusafw/asakusafw-sdk#109

## Wanted reviewer
N/A.
