### PR TITLE
Modify to use Asakusa distribution Gradle plug-in

### DIFF
--- a/example-basic-m3bp/build.gradle
+++ b/example-basic-m3bp/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw.m3bp', name: 'asakusa-m3bp-gradle', version: '0.2.0-SNAPSHOT'
+        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-basic-m3bp/build.gradle
+++ b/example-basic-m3bp/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
+        classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-basic-spark/build.gradle
+++ b/example-basic-spark/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw.spark', name: 'asakusa-spark-gradle', version: '0.4.0-SNAPSHOT'
+        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-basic-spark/build.gradle
+++ b/example-basic-spark/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
+        classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-directio-csv/build.gradle
+++ b/example-directio-csv/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw.spark', name: 'asakusa-spark-gradle', version: '0.4.0-SNAPSHOT'
+        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-directio-csv/build.gradle
+++ b/example-directio-csv/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
+        classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-directio-hive/build.gradle
+++ b/example-directio-hive/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw.spark', name: 'asakusa-spark-gradle', version: '0.4.0-SNAPSHOT'
+        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-directio-hive/build.gradle
+++ b/example-directio-hive/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
+        classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-directio-tsv/build.gradle
+++ b/example-directio-tsv/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw.spark', name: 'asakusa-spark-gradle', version: '0.4.0-SNAPSHOT'
+        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-directio-tsv/build.gradle
+++ b/example-directio-tsv/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
+        classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-multiproject/app-proj/build.gradle
+++ b/example-multiproject/app-proj/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw.spark', name: 'asakusa-spark-gradle', version: '0.4.0-SNAPSHOT'
+        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-multiproject/app-proj/build.gradle
+++ b/example-multiproject/app-proj/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
+        classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-multiproject/build.gradle
+++ b/example-multiproject/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw.spark', name: 'asakusa-spark-gradle', version: '0.4.0-SNAPSHOT'
+        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-multiproject/build.gradle
+++ b/example-multiproject/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
+        classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-multiproject/dmdl-proj/build.gradle
+++ b/example-multiproject/dmdl-proj/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw.spark', name: 'asakusa-spark-gradle', version: '0.4.0-SNAPSHOT'
+        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-multiproject/dmdl-proj/build.gradle
+++ b/example-multiproject/dmdl-proj/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
+        classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-multiproject/test-proj/build.gradle
+++ b/example-multiproject/test-proj/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw.spark', name: 'asakusa-spark-gradle', version: '0.4.0-SNAPSHOT'
+        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-multiproject/test-proj/build.gradle
+++ b/example-multiproject/test-proj/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
+        classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-summarize-sales/build.gradle
+++ b/example-summarize-sales/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw.spark', name: 'asakusa-spark-gradle', version: '0.4.0-SNAPSHOT'
+        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-summarize-sales/build.gradle
+++ b/example-summarize-sales/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
+        classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-windgate-csv/build.gradle
+++ b/example-windgate-csv/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw.spark', name: 'asakusa-spark-gradle', version: '0.4.0-SNAPSHOT'
+        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-windgate-csv/build.gradle
+++ b/example-windgate-csv/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
+        classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-windgate-jdbc/build.gradle
+++ b/example-windgate-jdbc/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw.spark', name: 'asakusa-spark-gradle', version: '0.4.0-SNAPSHOT'
+        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 

--- a/example-windgate-jdbc/build.gradle
+++ b/example-windgate-jdbc/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
-        classpath group: 'com.asakusafw', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
+        classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.9.0-SNAPSHOT'
     }
 }
 


### PR DESCRIPTION
## Summary
This PR modifies `build.gradle` on example projects to use Asakusa distribution Gradle plug-in ( asakusafw/asakusafw-distribution#1 ).

## Background, Problem or Goal of the patch
See asakusafw/asakusafw-distribution#1 .

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
asakusafw/asakusafw-distribution#1

## Wanted reviewer
N/A.

