### PR TITLE
Change maven repository URL to use https in build configurations

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Bug reports, Patch contribution
 * Please report any issues to [repository for issue tracking](https://github.com/asakusafw/asakusafw-issues/issues)
-* Please contribute with patches according to our [contribution guide (Japanese only, English version to be added)](http://docs.asakusafw.com/latest/release/ja/html/contribution.html)
+* Please contribute with patches according to our [contribution guide (Japanese only, English version to be added)](https://docs.asakusafw.com/latest/release/ja/html/contribution.html)
 
 ## Template of Issues or Pull Requests
 

--- a/example-basic-m3bp/README.md
+++ b/example-basic-m3bp/README.md
@@ -103,4 +103,4 @@ Then you should see the output files on `$HOME/target/testing/directio/result` d
 * [Asakusa on M<sup>3</sup>BP](https://github.com/asakusafw/asakusafw-m3bp)
 
 ## Resources
-* [Asakusa on M<sup>3</sup>BP Documentation (ja)](http://docs.asakusafw.com/asakusa-on-m3bp/)
+* [Asakusa on M<sup>3</sup>BP Documentation (ja)](https://docs.asakusafw.com/asakusa-on-m3bp/)

--- a/example-basic-m3bp/build.gradle
+++ b/example-basic-m3bp/build.gradle
@@ -2,8 +2,8 @@ group 'com.example'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.4-SNAPSHOT'

--- a/example-basic-spark/README.md
+++ b/example-basic-spark/README.md
@@ -67,7 +67,7 @@ find "$ASAKUSA_HOME" -name "*.sh" | xargs chmod u+x
 ### Requirements
 
 * Java SE Development Kit >= 1.8
-* [Apache Spark](http://spark.apache.org/) >= 2.0
+* [Apache Spark](https://spark.apache.org/) >= 2.0
 
 ### Setting sample data
 
@@ -105,4 +105,4 @@ Then you should see the output files on `$HOME/target/testing/directio/result` d
 * [Asakusa on Spark](https://github.com/asakusafw/asakusafw-spark)
 
 ## Resources
-* [Asakusa on Spark Documentation (ja)](http://docs.asakusafw.com/asakusa-on-spark/)
+* [Asakusa on Spark Documentation (ja)](https://docs.asakusafw.com/asakusa-on-spark/)

--- a/example-basic-spark/build.gradle
+++ b/example-basic-spark/build.gradle
@@ -2,8 +2,8 @@ group 'com.example'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.4-SNAPSHOT'

--- a/example-directio-csv/build.gradle
+++ b/example-directio-csv/build.gradle
@@ -2,8 +2,8 @@ group 'com.example'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.4-SNAPSHOT'

--- a/example-directio-hive/build.gradle
+++ b/example-directio-hive/build.gradle
@@ -2,8 +2,8 @@ group 'com.example'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.4-SNAPSHOT'

--- a/example-directio-tsv/build.gradle
+++ b/example-directio-tsv/build.gradle
@@ -2,8 +2,8 @@ group 'com.example'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.4-SNAPSHOT'

--- a/example-multiproject/app-proj/build.gradle
+++ b/example-multiproject/app-proj/build.gradle
@@ -2,8 +2,8 @@ group 'com.example'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.4-SNAPSHOT'

--- a/example-multiproject/build.gradle
+++ b/example-multiproject/build.gradle
@@ -2,8 +2,8 @@ group 'com.example'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.4-SNAPSHOT'

--- a/example-multiproject/dmdl-proj/build.gradle
+++ b/example-multiproject/dmdl-proj/build.gradle
@@ -2,8 +2,8 @@ group 'com.example'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.4-SNAPSHOT'

--- a/example-multiproject/test-proj/build.gradle
+++ b/example-multiproject/test-proj/build.gradle
@@ -2,8 +2,8 @@ group 'com.example'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.4-SNAPSHOT'

--- a/example-summarize-sales/build.gradle
+++ b/example-summarize-sales/build.gradle
@@ -2,8 +2,8 @@ group 'com.asakusafw.example.summarization'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.4-SNAPSHOT'

--- a/example-thundergate/build.gradle
+++ b/example-thundergate/build.gradle
@@ -2,8 +2,8 @@ group 'com.example.business'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw.legacy', name: 'asakusa-legacy-gradle', version: '0.9.0-SNAPSHOT'

--- a/example-windgate-csv/build.gradle
+++ b/example-windgate-csv/build.gradle
@@ -2,8 +2,8 @@ group 'com.asakusafw.example.csv'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.4-SNAPSHOT'

--- a/example-windgate-jdbc/build.gradle
+++ b/example-windgate-jdbc/build.gradle
@@ -2,8 +2,8 @@ group 'com.asakusafw.example.jdbc'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
         mavenCentral()
     }
     dependencies {


### PR DESCRIPTION
## Summary
This PR changes maven repository URL protocol from http to https in `build.gradle` for framework build configurations.
This also changes link URL to https in documentation files.

## Background, Problem or Goal of the patch
Follow-up asakusafw/asakusafw#845

## Design of the fix, or a new feature
The same as asakusafw/asakusafw#845

## Related Issue, Pull Request or Code
N/A.
