### PR TITLE
Fix distributionUrl of Gradle Wrapper in example-thundergate

### DIFF
--- a/example-thundergate/.buildtools/gradlew.properties
+++ b/example-thundergate/.buildtools/gradlew.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-bin.zip


### PR DESCRIPTION
## Summary
This PR fixes distributionUrl of Gradle Wrapper in example-thundergate project.

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.
